### PR TITLE
Update volume setup for LLVM as an external dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ The `setup.sh` script:
    directory and populates it with a fresh checkout of Kythe from GitHub.
    Local changes to the working copy will be preserved here.
 
--  Creates a separate persistent read-write volume for the LLVM installation.
-   This reduces the frequency with which you need to rebuild LLVM, which takes
-   forever.
+-  Creates a separate persistent read-write volume to cache build outputs.
+   This speeds up rebuilds, particularly for expensive toolchains like LLVM.
+   This volume can safely be purged at any time. A Bazel configuration is set
+   up to point to this volume as a `--disk_cache`.
 
 -  Builds and tags an image that contains all the build tools and external
    dependencies needed to build Kythe with Bazel.
 
--  (Re)starts a container and verifies that modules are up to date, which has
-   the effect of populating the LLVM volume.
+-  (Re)starts a container on the image.
 
 The script takes no arguments, and it should not be necessary to edit anything,
 but there are some configuration variables at the top which you can modify if
@@ -59,10 +59,9 @@ or, just edit the [Dockerfile](image/Dockerfile).
     ./kythebox/setup.sh
     ```
 
-    You can do this _without_ modifying the image or rebuilding LLVM.  If your
-	LLVM volume is pooched and needs replacement, you can do the same for
-	`kythe-dev-llvm`.  In that case you _will_ have to wait for LLFM to
-	rebuild, however.
+    You can do this _without_ modifying the image.  If your cache volume is
+	pooched and needs replacement, you can do the same for `kythe-dev-cache`.
+
 
  -  If you need to add items to the image, edit the
 	[Dockerfile](image/Dockerfile) and rerun `setup.sh` to rebuild the image:
@@ -71,5 +70,3 @@ or, just edit the [Dockerfile](image/Dockerfile).
     docker stop kythe-dev ; docker rm kythe-dev
     ./kythebox/setup.sh
     ```
-
-    This will not make you rebuild LLVM.  Thank heaven for small favours.

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -63,7 +63,7 @@ FROM scratch AS kythe
 # To update the repo, attach to the container and run "git pull" normally.
 #
 ARG HOMEDIR=/home/kythedev
-ARG LLVMDIR=/home/kythedev/kythe/third_party/llvm
+ARG CACHEDIR=/home/kythedev/buildcache
 COPY --from=clean / /
 RUN groupadd -g 501 kythedev && \
     useradd -r -m -u 501 -g kythedev kythedev && \
@@ -73,6 +73,6 @@ RUN groupadd -g 501 kythedev && \
     # We have to chmod sudo because COPY doesn't preserve that bit.
 USER    kythedev:kythedev
 ENV     CLANG=/usr/bin/clang-4.0 PATH="$HOMEDIR/go/bin:${PATH}"
-VOLUME  $HOMEDIR $LLVMDIR
+VOLUME  $HOMEDIR $CACHEDIR
 WORKDIR "$HOMEDIR"/kythe
 CMD     ["/bin/bash"]


### PR DESCRIPTION
kythe/kythe/pull/3422 replaced the script-driven LLVM build with a normal
external dependency that builds with Bazel. This means we can no longer
practically keep LLVM in a separate volume, as it is now folded together with
the other Bazel outputs.

Instead, rework the LLVM volume as a more general Bazel cache volume, and set
up ~/.bazelrc to include a --disk_cache flag pointing to it. This has the same
practical benefit of speeding up re-builds of LLVM, and in fact helps with any
build because it's shared.